### PR TITLE
Update get_image_size.py

### DIFF
--- a/get_image_size.py
+++ b/get_image_size.py
@@ -26,7 +26,8 @@ def get_image_size(file_path):
     """
     size = os.path.getsize(file_path)
 
-    with open(file_path) as input:
+    # be explicit with open arguments - we need binary mode
+    with open(file_path, "rb") as input:
         height = -1
         width = -1
         data = input.read(25)


### PR DESCRIPTION
So I was actually using this while I was working on a little game project - specifically one using the Ren'Py Visual Novel Engine.

To keep a long story short, while playtesting, I noticed that this Python module worked on my Mac machines, but not my Windows machines. As it turned out, Windows _needs_ the b argument (and the argument doesn't hurt the UNIX side of things); it was reading the image files in text mode.

"Python on Windows makes a distinction between text and binary files"

The module definitely made my life easier - it certainly isn't something I would have wanted to do the research for.
