### PR TITLE
BMP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ As you say, avoiding PIL is worth it for its own sake.
 Usage
 -----
 
-Right now only for PNG, JPEG and GIF. Very untested, fork and send PRs.
+Right now only for PNG, JPEG, GIF and BMP. Very untested, fork and send PRs.
 
     from get_image_size import get_image_size, UnknownImageFormat
 

--- a/get_image_size.py
+++ b/get_image_size.py
@@ -30,7 +30,7 @@ def get_image_size(file_path):
     with open(file_path, "rb") as input:
         height = -1
         width = -1
-        data = input.read(25)
+        data = input.read(26)
         msg = " raised while trying to decode as JPEG."
 
         if (size >= 10) and data[:6] in ('GIF87a', 'GIF89a'):
@@ -73,6 +73,19 @@ def get_image_size(file_path):
                 raise UnknownImageFormat("ValueError" + msg)
             except Exception as e:
                 raise UnknownImageFormat(e.__class__.__name__ + msg)
+        elif (size >= 2) and data.startswith('BM'):
+            # BMP
+            headersize = struct.unpack("<I", data[14:18])[0]
+            if headersize == 12:
+                raise UnknownImageFormat("Windows 2.0 (BITMAPCOREHEADER) and OS/2 1.x Bitmaps (OS21XBITMAPHEADER) are not supported.")
+            if headersize == 64:
+                raise UnknownImageFormat("OS/2 2.x Bitmaps (OS22XBITMAPHEADER) are not supported.")
+            if headersize >= 40:
+                w, h = struct.unpack("<ii", data[18:26])
+                width = int(w)
+                height = abs(int(h)) # as h is negative when stored upside down
+            else:
+                raise UnknownImageFormat("Unkown DIB header size:" + str(headersize))
         elif size >= 2:
         	#see http://en.wikipedia.org/wiki/ICO_(file_format)
         	input.seek(0)

--- a/get_image_size.py
+++ b/get_image_size.py
@@ -73,14 +73,14 @@ def get_image_size(file_path):
                 raise UnknownImageFormat("ValueError" + msg)
             except Exception as e:
                 raise UnknownImageFormat(e.__class__.__name__ + msg)
-        elif (size >= 2) and data.startswith('BM'):
+        elif (size >= 26) and data.startswith('BM'):
             # BMP
             headersize = struct.unpack("<I", data[14:18])[0]
             if headersize == 12:
-                raise UnknownImageFormat("Windows 2.0 (BITMAPCOREHEADER) and OS/2 1.x Bitmaps (OS21XBITMAPHEADER) are not supported.")
-            if headersize == 64:
-                raise UnknownImageFormat("OS/2 2.x Bitmaps (OS22XBITMAPHEADER) are not supported.")
-            if headersize >= 40:
+                w, h = struct.unpack("<HH", data[18:22])
+                width = int(w)
+                height = int(h)
+            elif headersize >= 40:
                 w, h = struct.unpack("<ii", data[18:26])
                 width = int(w)
                 height = abs(int(h)) # as h is negative when stored upside down


### PR DESCRIPTION
I added support for BMP file types, respecting different types of DIB headers. Should work on all current bitmap types, tested for old OS/2 and BITMAPCOREHEADER files, too. You might try it and consider it for merging if you find it useful.

No longer under 100 LOC though, sorry ;)