### PR TITLE
TIF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ As you say, avoiding PIL is worth it for its own sake.
 Usage
 -----
 
-Right now only for PNG, JPEG, GIF and BMP. Very untested, fork and send PRs.
+Right now only for PNG, JPEG, GIF, BMP and TIF. Very untested, fork and send PRs.
 
     from get_image_size import get_image_size, UnknownImageFormat
 


### PR DESCRIPTION
I now also added TIFF format support for a variety of different types. Separate derivatives of TIFF (i.e. separate but TIFF-like formats like BigTIFF etc) are currently not supported. 
When the weather is bad I might add some more formats. 
Also I noticed an issue about .startswith() for newer Python versions which is used for PNG, JPEG and BMP; I'll look at that later.